### PR TITLE
Fix red label persistence

### DIFF
--- a/Form1.vb
+++ b/Form1.vb
@@ -660,6 +660,11 @@ Public Class form1
                     tiempo_de_vuelta(corredor_2) = TiempoultimavueltaTomada(corredor_2)
                     Tiempodeultimavueltatratada(corredor_2) = TiempoultimavueltaTomada(corredor_2)
 
+                    'Reset backcolor when receiving a fresh update
+                    If asignadolabel(corredor_2) Then
+                        lblmoto(corredor_2).BackColor = Color.GreenYellow
+                    End If
+
                     If tiempo_de_vuelta(corredor_2) = 0 Then tiempo_de_vuelta(corredor_2) = 120
 
 


### PR DESCRIPTION
## Summary
- reset label background when a fresh update for a pilot is processed

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687b801b6668832e95830645f926f7d8